### PR TITLE
Add Berksfile file

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,6 @@
+source 'https://supermarket.getchef.com'
+
+# We want to be explicit, since we don't explicitly include our
+# packages, except when testing
+cookbook 'build-essential', '1.4.2'
+cookbook 'git', '3.1.0'


### PR DESCRIPTION
I needed to add the Berksfile as I was getting an error while trying to use the phalcon recipe. 

Here is the error log
`INFO: HTTP Request Returned 412 Precondition Failed: No such cookbook: git`

Adding the Berksfile worked, but one has to set "Manage Berkshelf" to "Yes" in the Stack settings
